### PR TITLE
Add manifest file to get HA to load the component.

### DIFF
--- a/custom_components/hive/manifest.json
+++ b/custom_components/hive/manifest.json
@@ -1,0 +1,13 @@
+{
+    "domain": "hive",
+    "name": "Hive",
+    "documentation": "https://www.home-assistant.io/components/hive",
+    "requirements": [
+      "pyhiveapi==0.2.17"
+    ],
+    "dependencies": [],
+    "codeowners": [
+      "@Rendili",
+      "@KJonline"
+    ]
+  }


### PR DESCRIPTION
The hive custom component refuses to load unless a manifest is provided. This is in spite of the documentation of HA saying that one is not necessary.